### PR TITLE
feed: Add "content-type" prop to all the models

### DIFF
--- a/src/feed-knowledge-app-artwork-card-store.c
+++ b/src/feed-knowledge-app-artwork-card-store.c
@@ -163,7 +163,8 @@ eos_discovery_feed_knowledge_app_artwork_card_store_new (const gchar            
                                                          const gchar                         *knowledge_app_id,
                                                          EosDiscoveryFeedCardLayoutDirection  layout_direction,
                                                          guint                                thumbnail_size,
-                                                         const gchar                         *thumbnail_uri)
+                                                         const gchar                         *thumbnail_uri,
+                                                         const gchar                         *content_type)
 {
   return g_object_new (EOS_DISCOVERY_FEED_TYPE_KNOWLEDGE_APP_ARTWORK_CARD_STORE,
                        "title", title,
@@ -178,5 +179,6 @@ eos_discovery_feed_knowledge_app_artwork_card_store_new (const gchar            
                        "layout-direction", layout_direction,
                        "thumbnail-size", thumbnail_size,
                        "thumbnail-uri", thumbnail_uri,
+                       "content-type", content_type,
                        NULL);
 }

--- a/src/feed-knowledge-app-artwork-card-store.h
+++ b/src/feed-knowledge-app-artwork-card-store.h
@@ -39,7 +39,7 @@ EosDiscoveryFeedKnowledgeAppArtworkCardStore * eos_discovery_feed_knowledge_app_
                                                                                                         EosDiscoveryFeedCardLayoutDirection  layout_direction,
                                                                                                         guint                                thumbnail_size,
                                                                                                         const gchar                         *thumbnail_uri,
-                                                                                                        const gchar                        *content_type);
+                                                                                                        const gchar                         *content_type);
 
 
 

--- a/src/feed-knowledge-app-artwork-card-store.h
+++ b/src/feed-knowledge-app-artwork-card-store.h
@@ -38,7 +38,8 @@ EosDiscoveryFeedKnowledgeAppArtworkCardStore * eos_discovery_feed_knowledge_app_
                                                                                                         const gchar                         *knowledge_app_id,
                                                                                                         EosDiscoveryFeedCardLayoutDirection  layout_direction,
                                                                                                         guint                                thumbnail_size,
-                                                                                                        const gchar                         *thumbnail_uri);
+                                                                                                        const gchar                         *thumbnail_uri,
+                                                                                                        const gchar                        *content_type);
 
 
 

--- a/src/feed-knowledge-app-card-store.c
+++ b/src/feed-knowledge-app-card-store.c
@@ -36,6 +36,7 @@ typedef struct _EosDiscoveryFeedKnowledgeAppCardStorePrivate
   gchar                               *thumbnail_uri;
   EosDiscoveryFeedCardLayoutDirection  layout_direction;
   guint                                thumbnail_size;
+  gchar                               *content_type;
 } EosDiscoveryFeedKnowledgeAppCardStorePrivate;
 
 static void base_card_store_iface_init (EosDiscoveryFeedBaseCardStoreInterface *iface);
@@ -59,6 +60,7 @@ enum {
   PROP_LAYOUT_DIRECTION,
   PROP_THUMBNAIL_SIZE,
   PROP_THUMBNAIL_URI,
+  PROP_CONTENT_TYPE,
   PROP_TYPE,
   NPROPS
 };
@@ -105,6 +107,9 @@ eos_discovery_feed_knowledge_app_card_store_set_property (GObject      *object,
       break;
     case PROP_THUMBNAIL_URI:
       priv->thumbnail_uri = g_value_dup_string (value);
+      break;
+    case PROP_CONTENT_TYPE:
+      priv->content_type = g_value_dup_string (value);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -155,6 +160,9 @@ eos_discovery_feed_knowledge_app_card_store_get_property (GObject    *object,
     case PROP_THUMBNAIL_URI:
       g_value_set_string (value, priv->thumbnail_uri);
       break;
+    case PROP_CONTENT_TYPE:
+      g_value_set_string (value, priv->content_type);
+      break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
@@ -172,6 +180,7 @@ eos_discovery_feed_knowledge_app_card_store_finalize (GObject *object)
   g_clear_pointer (&priv->bus_name, g_free);
   g_clear_pointer (&priv->knowledge_search_object_path, g_free);
   g_clear_pointer (&priv->knowledge_app_id, g_free);
+  g_clear_pointer (&priv->content_type, g_free);
 
   G_OBJECT_CLASS (eos_discovery_feed_knowledge_app_card_store_parent_class)->finalize (object);
 }
@@ -280,6 +289,13 @@ eos_discovery_feed_knowledge_app_card_store_class_init (EosDiscoveryFeedKnowledg
                          "",
                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY);
 
+  eos_discovery_feed_knowledge_app_card_store_props[PROP_CONTENT_TYPE] =
+    g_param_spec_string ("content-type",
+                         "Content Type",
+                         "MIME type for the underlying content",
+                         "",
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY);
+
   g_object_class_install_properties (object_class,
                                      PROP_TYPE,
                                      eos_discovery_feed_knowledge_app_card_store_props);
@@ -300,7 +316,8 @@ eos_discovery_feed_knowledge_app_card_store_new (const gchar                    
                                                  const gchar                         *knowledge_app_id,
                                                  EosDiscoveryFeedCardLayoutDirection  layout_direction,
                                                  guint                                thumbnail_size,
-                                                 const gchar                         *thumbnail_uri)
+                                                 const gchar                         *thumbnail_uri,
+                                                 const gchar                         *content_type)
 {
   return g_object_new (EOS_DISCOVERY_FEED_TYPE_KNOWLEDGE_APP_CARD_STORE,
                        "title", title,
@@ -314,5 +331,6 @@ eos_discovery_feed_knowledge_app_card_store_new (const gchar                    
                        "layout-direction", layout_direction,
                        "thumbnail-size", thumbnail_size,
                        "thumbnail-uri", thumbnail_uri,
+                       "content-type", content_type,
                        NULL);
 }

--- a/src/feed-knowledge-app-card-store.h
+++ b/src/feed-knowledge-app-card-store.h
@@ -38,6 +38,7 @@ EosDiscoveryFeedKnowledgeAppCardStore * eos_discovery_feed_knowledge_app_card_st
                                                                                          const gchar                         *knowledge_app_id,
                                                                                          EosDiscoveryFeedCardLayoutDirection  layout_direction,
                                                                                          guint                                thumbnail_size,
-                                                                                         const gchar                         *thumbnail_uri);
+                                                                                         const gchar                         *thumbnail_uri,
+                                                                                         const gchar                         *content_type);
 
 G_END_DECLS

--- a/src/feed-knowledge-app-news-card-store.c
+++ b/src/feed-knowledge-app-news-card-store.c
@@ -87,7 +87,8 @@ eos_discovery_feed_knowledge_app_news_card_store_new (const gchar               
                                                       const gchar                         *knowledge_app_news_id,
                                                       EosDiscoveryFeedCardLayoutDirection  layout_direction,
                                                       guint                                thumbnail_size,
-                                                      const gchar                         *thumbnail_uri)
+                                                      const gchar                         *thumbnail_uri,
+                                                      const gchar                         *content_type)
 {
   return g_object_new (EOS_DISCOVERY_FEED_TYPE_KNOWLEDGE_APP_NEWS_CARD_STORE,
                        "title", title,
@@ -101,5 +102,6 @@ eos_discovery_feed_knowledge_app_news_card_store_new (const gchar               
                        "layout-direction", layout_direction,
                        "thumbnail-size", thumbnail_size,
                        "thumbnail-uri", thumbnail_uri,
+                       "content-type", content_type,
                        NULL);
 }

--- a/src/feed-knowledge-app-news-card-store.h
+++ b/src/feed-knowledge-app-news-card-store.h
@@ -43,6 +43,6 @@ EosDiscoveryFeedKnowledgeAppNewsCardStore * eos_discovery_feed_knowledge_app_new
                                                                                                   EosDiscoveryFeedCardLayoutDirection  layout_direction,
                                                                                                   guint                                thumbnail_size,
                                                                                                   const gchar                         *thumbnail_uri,
-                                                                                                  const gchar                              *content_type);
+                                                                                                  const gchar                         *content_type);
 
 G_END_DECLS

--- a/src/feed-knowledge-app-news-card-store.h
+++ b/src/feed-knowledge-app-news-card-store.h
@@ -42,6 +42,7 @@ EosDiscoveryFeedKnowledgeAppNewsCardStore * eos_discovery_feed_knowledge_app_new
                                                                                                   const gchar                         *knowledge_app_news_id,
                                                                                                   EosDiscoveryFeedCardLayoutDirection  layout_direction,
                                                                                                   guint                                thumbnail_size,
-                                                                                                  const gchar                         *thumbnail_uri);
+                                                                                                  const gchar                         *thumbnail_uri,
+                                                                                                  const gchar                              *content_type);
 
 G_END_DECLS

--- a/src/feed-knowledge-app-video-card-store.c
+++ b/src/feed-knowledge-app-video-card-store.c
@@ -143,7 +143,8 @@ eos_discovery_feed_knowledge_app_video_card_store_new (const gchar  *title,
                                                        const gchar  *bus_name,
                                                        const gchar  *knowledge_search_object_path,
                                                        const gchar  *knowledge_app_id,
-                                                       const gchar  *thumbnail_uri)
+                                                       const gchar  *thumbnail_uri,
+                                                       const gchar  *content_type)
 {
   return g_object_new (EOS_DISCOVERY_FEED_TYPE_KNOWLEDGE_APP_VIDEO_CARD_STORE,
                        "title", title,
@@ -155,5 +156,6 @@ eos_discovery_feed_knowledge_app_video_card_store_new (const gchar  *title,
                        "knowledge-search-object-path", knowledge_search_object_path,
                        "knowledge-app-id", knowledge_app_id,
                        "thumbnail-uri", thumbnail_uri,
+                       "content-type", content_type,
                        NULL);
 }

--- a/src/feed-knowledge-app-video-card-store.h
+++ b/src/feed-knowledge-app-video-card-store.h
@@ -35,6 +35,7 @@ EosDiscoveryFeedKnowledgeAppVideoCardStore * eos_discovery_feed_knowledge_app_vi
                                                                                                     const gchar  *bus_name,
                                                                                                     const gchar  *knowledge_search_object_path,
                                                                                                     const gchar  *knowledge_app_id,
-                                                                                                    const gchar  *thumbnail_uri);
+                                                                                                    const gchar  *thumbnail_uri,
+                                                                                                    const gchar  *content_type);
 
 G_END_DECLS

--- a/src/feed-store-provider.c
+++ b/src/feed-store-provider.c
@@ -207,7 +207,8 @@ typedef EosDiscoveryFeedKnowledgeAppCardStore * (*EosDiscoveryFeedKnowledgeAppCa
                                                                                                      const gchar                         *knowledge_app_id,
                                                                                                      EosDiscoveryFeedCardLayoutDirection  layout_direction,
                                                                                                      guint                                thumbnail_size,
-                                                                                                     const gchar                         *thumbnail_uri);
+                                                                                                     const gchar                         *thumbnail_uri,
+                                                                                                     const gchar                           *content_type);
 
 
 typedef struct _ArticleCardsFromShardsAndItemsData
@@ -280,6 +281,8 @@ article_cards_from_shards_and_items (const char * const *shards_strv,
       const gchar *ekn_id = lookup_string_in_dict_variant (model_props, "ekn_id");
       const gchar *thumbnail_uri = lookup_string_in_dict_variant (model_props,
                                                                   "thumbnail_uri");
+      const gchar *content_type = lookup_string_in_dict_variant (model_props,
+                                                                 "content_type");
       g_autoptr(GInputStream) thumbnail_stream =
         find_thumbnail_stream_in_shards (shards_strv, thumbnail_uri);
       GDBusProxy *dbus_proxy = eos_discovery_feed_knowledge_app_proxy_get_dbus_proxy (data->ka_proxy);
@@ -295,7 +298,8 @@ article_cards_from_shards_and_items (const char * const *shards_strv,
                        eos_discovery_feed_knowledge_app_proxy_get_knowledge_app_id (data->ka_proxy),
                        data->direction ? data->direction : EOS_DISCOVERY_FEED_CARD_LAYOUT_DIRECTION_IMAGE_FIRST,
                        data->thumbnail_size,
-                       thumbnail_uri);
+                       thumbnail_uri,
+                       content_type);
       orderable_stores = g_slist_prepend (orderable_stores,
                                           eos_discovery_feed_orderable_model_new (EOS_DISCOVERY_FEED_BASE_CARD_STORE (store),
                                                                                   data->type,
@@ -457,6 +461,8 @@ video_cards_from_shards_and_items (const char * const *shards_strv,
                                                                   "thumbnail_uri");
       const gchar *title = lookup_string_in_dict_variant (model_props, "title");
       const gchar *ekn_id = lookup_string_in_dict_variant (model_props, "ekn_id");
+      const gchar *content_type = lookup_string_in_dict_variant (model_props,
+                                                                 "content_type");
       g_autofree gchar *duration = parse_duration (in_duration, &local_error);
       g_autoptr(GInputStream) thumbnail_stream = NULL;
       EosDiscoveryFeedKnowledgeAppVideoCardStore *store = NULL;
@@ -480,7 +486,8 @@ video_cards_from_shards_and_items (const char * const *shards_strv,
                                                                      g_dbus_proxy_get_name (dbus_proxy),
                                                                      eos_discovery_feed_knowledge_app_proxy_get_knowledge_search_object_path (ka_proxy),
                                                                      eos_discovery_feed_knowledge_app_proxy_get_knowledge_app_id (ka_proxy),
-                                                                     thumbnail_uri);
+                                                                     thumbnail_uri,
+                                                                     content_type);
       orderable_stores = g_slist_prepend (orderable_stores,
                                           eos_discovery_feed_orderable_model_new (EOS_DISCOVERY_FEED_BASE_CARD_STORE (store),
                                                                                   EOS_DISCOVERY_FEED_CARD_STORE_TYPE_VIDEO_CARD,
@@ -525,6 +532,7 @@ artwork_cards_from_shards_and_items (const char * const *shards_strv,
       const gchar *title = lookup_string_in_dict_variant (model_props, "title");
       const gchar *ekn_id = lookup_string_in_dict_variant (model_props, "ekn_id");
       const gchar *author = lookup_string_in_dict_variant (model_props, "author");
+      const gchar *content_type = lookup_string_in_dict_variant (model_props, "content_type");
       g_autoptr(GInputStream) thumbnail_stream =
         find_thumbnail_stream_in_shards (shards_strv, thumbnail_uri);
       GDBusProxy *dbus_proxy = eos_discovery_feed_knowledge_app_proxy_get_dbus_proxy (ka_proxy);
@@ -541,7 +549,8 @@ artwork_cards_from_shards_and_items (const char * const *shards_strv,
                                                                  eos_discovery_feed_knowledge_app_proxy_get_knowledge_app_id (ka_proxy),
                                                                  EOS_DISCOVERY_FEED_CARD_LAYOUT_DIRECTION_IMAGE_FIRST,
                                                                  EOS_DISCOVERY_FEED_THUMBNAIL_SIZE_ARTWORK,
-                                                                 thumbnail_uri);
+                                                                 thumbnail_uri,
+                                                                 content_type);
       orderable_stores = g_slist_prepend (orderable_stores,
                                           eos_discovery_feed_orderable_model_new (EOS_DISCOVERY_FEED_BASE_CARD_STORE (store),
                                                                                   EOS_DISCOVERY_FEED_CARD_STORE_TYPE_ARTWORK_CARD,

--- a/src/feed-store-provider.c
+++ b/src/feed-store-provider.c
@@ -208,7 +208,7 @@ typedef EosDiscoveryFeedKnowledgeAppCardStore * (*EosDiscoveryFeedKnowledgeAppCa
                                                                                                      EosDiscoveryFeedCardLayoutDirection  layout_direction,
                                                                                                      guint                                thumbnail_size,
                                                                                                      const gchar                         *thumbnail_uri,
-                                                                                                     const gchar                           *content_type);
+                                                                                                     const gchar                         *content_type);
 
 
 typedef struct _ArticleCardsFromShardsAndItemsData


### PR DESCRIPTION
This is needed by the companion app to work out how to open
each piece of content correctly.

https://phabricator.endlessm.com/T22203