### PR TITLE
T21878: Improve sentence truncation and ellipsization logic

### DIFF
--- a/src/feed-text-sanitization.c
+++ b/src/feed-text-sanitization.c
@@ -23,7 +23,10 @@
 
 #include "config.h"
 
-#define CHARACTER_COUNT_THRESHOLD 60
+/* Don't take any more sentences if they would cause the number of
+ * lines to go above roughly three. However, we always take the first
+ * sentence, see below. */
+#define CHARACTER_COUNT_THRESHOLD 160
 
 static gchar *
 regex_replace (const gchar *exp, const gchar *str, const gchar *replacement)
@@ -78,7 +81,10 @@ trim_to_first_n_sentences_under_threshold (const gchar *str,
       if (sentence_length == 0)
         continue;
 
-      if ((character_count + sentence_length_with_period) > character_threshold)
+      /* Even if the sentence would be longer than the character threshold
+       * we should always take it. We'll ellipsize it later at a word boundary. */
+      if ((character_count + sentence_length_with_period) > character_threshold &&
+          sentences->len > 0)
         break;
 
       g_ptr_array_add (sentences, *iter);

--- a/src/feed-text-sanitization.c
+++ b/src/feed-text-sanitization.c
@@ -114,13 +114,23 @@ static gchar *
 add_ending_period (const gchar *str)
 {
   guint len = strlen (str);
-  g_autofree gchar *ending_period = g_new0 (gchar, len + 2);
 
-  strcpy (ending_period, str);
-  ending_period[len] = '.';
-  ending_period[len + 1] = '\0';
+  /* Don't add ending period if the string had no length.
+   *
+   * This might be the case if the model had no synopsis, like those
+   * having hook titles. */
+  if (len > 0)
+    {
+      g_autofree gchar *ending_period = g_new0 (gchar, len + 2);
 
-  return g_steal_pointer (&ending_period);
+      strcpy (ending_period, str);
+      ending_period[len] = '.';
+      ending_period[len + 1] = '\0';
+
+      return g_steal_pointer (&ending_period);
+    }
+
+  return g_strdup (str);
 }
 
 gchar *


### PR DESCRIPTION
The previous approach truncated sentences too soon and didn't mix very well with Gtk's built in ellipsization (Gtk ellipsizes on characters and not word boundaries). This PR always allows the first sentence to be added, but prevents new sentences from being added if they would go past 160 chars. If the buffer is still > 220 chars (for instance, a very long initial sentence), then it is ellipsized on the word boundary.

https://phabricator.endlessm.com/T21878